### PR TITLE
Keep up with modern times in clippy invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ rust:
 
 before_script: |
   rustup component add rustfmt-preview &&
-  cargo install clippy -f
+  rustup component add clippy-preview
 script: |
   cargo fmt -- --check &&
-  cargo clippy -- -D clippy &&
+  cargo clippy -- -D clippy::all &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,3 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1.1"
-
-[dev-dependencies]
-# clippy = "0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 #![cfg_attr(test, deny(warnings))]
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
-// #![cfg_attr(test, feature(plugin))]
-// #![cfg_attr(test, plugin(clippy))]
 
 extern crate failure;
 


### PR DESCRIPTION
This is a 🐛 bug fix.

Fixes the following warning:
`warning: lint name `clippy` is deprecated and does not have an effect anymore. Use: clippy::all`

## Checklist

- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver Changes
None
